### PR TITLE
Specify the eltype of the iterator

### DIFF
--- a/src/TiledIteration.jl
+++ b/src/TiledIteration.jl
@@ -41,6 +41,8 @@ end
 ceildiv(l, s) = ceil(Int, l/s)
 
 Base.length(iter::TileIterator) = length(iter.R)
+Base.eltype{N}(iter::TileIterator{N}) = NTuple{N,UnitRange{Int}}
+
 @inline Base.start(iter::TileIterator) = start(iter.R)
 @inline function Base.next(iter::TileIterator, state)
     I, newstate = next(iter.R, state)

--- a/src/TiledIteration.jl
+++ b/src/TiledIteration.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module TiledIteration
 
 using OffsetArrays

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using TiledIteration
+using TiledIteration, OffsetArrays
 using Base.Test
 
 @testset "tiled iteration" begin
@@ -6,7 +6,7 @@ using Base.Test
     for i1 = -3:2, i2 = -1:5
         for l1 = 2:13, l2 = 1:16
             inds = (i1:i1+l1-1, i2:i2+l2-1)
-            A = zeros(Int, inds...)
+            A = fill!(OffsetArray{Int}(inds), 0)
             k = 0
             for tileinds in TileIterator(inds, sz)
                 tile = A[tileinds...]
@@ -15,6 +15,7 @@ using Base.Test
                 A[tileinds...] = (k+=1)
             end
             @test minimum(A) == 1
+            @test eltype(collect(TileIterator(inds, sz))) == Tuple{UnitRange{Int}, UnitRange{Int}}
         end
     end
 end


### PR DESCRIPTION
`collect` was returning a `Vector{Any}`, which was not ideal.